### PR TITLE
Fix horizontal scrolling on devices with 1200px

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -215,10 +215,4 @@ border: 2px solid #fff;
   .home-layout {
     padding: 60px 120px 20px;
   }
-
-  .main-header img {
-    width: auto;
-    height: auto;
-    margin: 0 auto;
-  }
 }


### PR DESCRIPTION
On devices with width greater than or equal to `1200px`, the page shows a horizontal scrolling, which makes the page not really centered and bothers the reader

<img width="1280" alt="screenshot 2018-12-09 at 20 59 09" src="https://user-images.githubusercontent.com/3688136/49702274-c6c31380-fbf6-11e8-9f13-9b813f92e9c8.png">
